### PR TITLE
Configuration for default proxy use & authentication

### DIFF
--- a/App.config
+++ b/App.config
@@ -21,4 +21,9 @@
             </setting>
         </Wallcat.Properties.Settings>
     </userSettings>
+    <system.net>
+        <defaultProxy enabled="true" useDefaultCredentials="true">
+            <proxy usesystemdefault="True"/>
+        </defaultProxy>
+    </system.net>
 </configuration>


### PR DESCRIPTION
Currently there is no way for the app to work from behind a proxy. I have added configuration enabling use of default system proxy and authentication method to app.config.